### PR TITLE
Add section for 'yarn install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 In the project directory, you can run:
 
+### `yarn install`
+
+Resolves and installs the project's dependencies. Run this when you've first cloned the repo.
+
 ### `yarn start`
 
 Runs the app in the development mode.\


### PR DESCRIPTION
Adding a section about `yarn install`, mentioning that it should be run first, after cloning the repo. This addresses issue #19 